### PR TITLE
Parentheses in numbers

### DIFF
--- a/modelmapper/__init__.py
+++ b/modelmapper/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 import sys
 pyversion = float(sys.version[:3])
 if pyversion < 3.6:

--- a/modelmapper/mapper.py
+++ b/modelmapper/mapper.py
@@ -161,14 +161,16 @@ INTEGER_SQLALCHEMY_TYPES = {
     SqlalchemyFieldType.Integer,
     SqlalchemyFieldType.BigInteger
 }
-NUMERIC_REMOVE = (',', '$', '%', '(', ')', '-')
+
+NUMERIC_REMOVE = (',', '$', '%', '-')
 
 
 def _remove_extra_chars_from_number(item, absolute=False):
-    if not absolute and item.startswith('(') and item.endswith(')'):
+    if item.startswith('(') and item.endswith(')'):
+        item = item.strip('()')
         item = f'-{item}'
     for i in NUMERIC_REMOVE:
-        if not(absolute and i == '-'):
+        if not(i == '-' and not absolute):
             item = item.replace(i, '')
     return item
 

--- a/modelmapper/mapper.py
+++ b/modelmapper/mapper.py
@@ -146,6 +146,9 @@ class SqlalchemyFieldType(enum.Enum):
         return SqlalchemyFieldTypeToHas[self._name_]
 
 
+# The priority of these field types when deciding between the types during
+# csv results combining phase.
+# The field with high number will overwrite the values from the lower field.
 FIELD_RESULT_COMPARISON_NUMBERS = {
     SqlalchemyFieldType.Decimal: 10,
     SqlalchemyFieldType.BigInteger: 8,
@@ -158,11 +161,20 @@ INTEGER_SQLALCHEMY_TYPES = {
     SqlalchemyFieldType.Integer,
     SqlalchemyFieldType.BigInteger
 }
-NUMERIC_REMOVE = (',', '$', '%')
+NUMERIC_REMOVE = (',', '$', '%', '(', ')', '-')
+
+
+def _remove_extra_chars_from_number(item, absolute=False):
+    if not absolute and item.startswith('(') and item.endswith(')'):
+        item = f'-{item}'
+    for i in NUMERIC_REMOVE:
+        if not(absolute and i == '-'):
+            item = item.replace(i, '')
+    return item
 
 
 def get_positive_int(item):
-    item = item.replace('-', '').replace(',', '')
+    item = _remove_extra_chars_from_number(item, absolute=True)
     try:
         result = int(item)
     except ValueError:
@@ -171,7 +183,7 @@ def get_positive_int(item):
 
 
 def get_positive_decimal(item):
-    item = item.replace('-', '').replace(',', '')
+    item = _remove_extra_chars_from_number(item, absolute=True)
     try:
         result = Decimal(item)
     except decimal.InvalidOperation:
@@ -741,11 +753,6 @@ class Mapper:
 
         def _mark_nulls(item):
             return None if item in self.settings.null_values else item
-
-        def _remove_extra_chars_from_number(item):
-            for i in NUMERIC_REMOVE:
-                item = item.replace(i, '')
-            return item
 
         def _mark_booleans(item):
             if item in self.settings.boolean_true:

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -142,6 +142,11 @@ class TestMapper:
                     max_int=0, len=3, max_decimal_scale=2, max_pre_decimal=4),
          FieldResult(field_db_sqlalchemy_type=SqlalchemyFieldType.Integer, field_db_str='Integer', is_nullable=True, is_dollar=True)
          ),
+        # (['$0.00', '($12,000.00)', '$7,765.00'],
+        #  FieldStats(counter=Counter({'HasDollar': 3, 'HasDecimal': 3}),
+        #             max_int=0, max_pre_decimal=5, max_decimal_scale=2, len=3),
+        #  FieldResult(field_db_sqlalchemy_type=SqlalchemyFieldType.Integer, field_db_str='Integer', is_nullable=True, is_dollar=True)
+        #  ),
         ])
     @mock.patch('modelmapper.mapper.get_user_input', return_value='somehow passed validation')
     @mock.patch('modelmapper.mapper.get_user_choice')

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -7,10 +7,10 @@ from deepdiff import DeepDiff
 from modelmapper import Mapper
 from modelmapper.mapper import FieldStats, InconsistentData, FieldResult, SqlalchemyFieldType, get_field_result_from_dict
 from fixtures.training_fixture1_mapping import all_fixture1_values, all_field_results_fixture1, all_field_sqlalchemy_str_fixture1  # NOQA
-from fixtures.analysis_fixtures import (analysis_fixture_a, analysis_fixture_b, analysis_fixture_c, override_fixture1,
+from fixtures.analysis_fixtures import (analysis_fixture_a, analysis_fixture_b, override_fixture1,
                                         analysis_fixture_a_only_combined, analysis_fixture_a_and_b_combined,
                                         analysis_fixture_a_and_b_combined_with_override)
-from fixtures.cleaned_csv_for_importing import cleaned_csv_for_import_fixture
+from fixtures.cleaned_csv_for_importing import cleaned_csv_for_import_fixture  # NOQA
 
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -92,6 +92,11 @@ class TestMapper:
                     max_int=20, len=5),
          FieldResult(field_db_sqlalchemy_type=SqlalchemyFieldType.SmallInteger, field_db_str='SmallInteger', is_nullable=True)
          ),
+        (['1', '1', '0', '0', '(20)'],
+         FieldStats(counter=Counter(HasBoolean=4, HasInt=5),
+                    max_int=20, len=5),
+         FieldResult(field_db_sqlalchemy_type=SqlalchemyFieldType.SmallInteger, field_db_str='SmallInteger', is_nullable=True)
+         ),
         (['$1.92', '$33.6', '$0', 'null', '$13000.22'],
          FieldStats(counter=Counter(HasNull=1, HasDecimal=3, HasInt=1, HasDollar=4),
                     max_pre_decimal=5, max_decimal_scale=2, len=5),
@@ -124,29 +129,29 @@ class TestMapper:
          ),
         (['1.102933', '220.23', '0'],
          FieldStats(counter=Counter(HasInt=1, HasDecimal=2, HasBoolean=1),
-                    max_int=0, len=3, max_decimal_scale=6, max_pre_decimal=3),
+                    len=3, max_decimal_scale=6, max_pre_decimal=3),
          FieldResult(field_db_sqlalchemy_type=SqlalchemyFieldType.Decimal, field_db_str='DECIMAL(13, 8)', is_nullable=True)
          ),
         (['1.102933%', '220.23%', '0%'],
          FieldStats(counter=Counter(HasPercent=3, HasInt=1, HasDecimal=2),
-                    max_int=0, len=3, max_decimal_scale=6, max_pre_decimal=3),
+                    len=3, max_decimal_scale=6, max_pre_decimal=3),
          FieldResult(field_db_sqlalchemy_type=SqlalchemyFieldType.Decimal, field_db_str='DECIMAL(13, 10)', is_nullable=True, is_percent=True)
          ),
         (['1,001.10', '220.23', '0'],
          FieldStats(counter=Counter(HasInt=1, HasDecimal=2, HasBoolean=1),
-                    max_int=0, len=3, max_decimal_scale=2, max_pre_decimal=4),
+                    len=3, max_decimal_scale=2, max_pre_decimal=4),
          FieldResult(field_db_sqlalchemy_type=SqlalchemyFieldType.Decimal, field_db_str='DECIMAL(10, 4)', is_nullable=True)
          ),
         (['$1,001.10', '$220.23', '0'],
          FieldStats(counter=Counter(HasInt=1, HasDecimal=2, HasBoolean=1, HasDollar=2),
-                    max_int=0, len=3, max_decimal_scale=2, max_pre_decimal=4),
+                    len=3, max_decimal_scale=2, max_pre_decimal=4),
          FieldResult(field_db_sqlalchemy_type=SqlalchemyFieldType.Integer, field_db_str='Integer', is_nullable=True, is_dollar=True)
          ),
-        # (['$0.00', '($12,000.00)', '$7,765.00'],
-        #  FieldStats(counter=Counter({'HasDollar': 3, 'HasDecimal': 3}),
-        #             max_int=0, max_pre_decimal=5, max_decimal_scale=2, len=3),
-        #  FieldResult(field_db_sqlalchemy_type=SqlalchemyFieldType.Integer, field_db_str='Integer', is_nullable=True, is_dollar=True)
-        #  ),
+        (['$0.00', '($12,000.00)', '$7,765.00'],
+         FieldStats(counter=Counter({'HasDollar': 3, 'HasDecimal': 3}),
+                    max_pre_decimal=5, max_decimal_scale=2, len=3),
+         FieldResult(field_db_sqlalchemy_type=SqlalchemyFieldType.Integer, field_db_str='Integer', is_nullable=True, is_dollar=True)
+         ),
         ])
     @mock.patch('modelmapper.mapper.get_user_input', return_value='somehow passed validation')
     @mock.patch('modelmapper.mapper.get_user_choice')
@@ -215,6 +220,6 @@ class TestMapper:
         diff = DeepDiff(expected, result)
         assert not diff
 
-    def test_get_csv_data_cleaned(self, mapper, cleaned_csv_for_import_fixture):
+    def test_get_csv_data_cleaned(self, mapper, cleaned_csv_for_import_fixture):  # NOQA
         result = list(mapper.get_csv_data_cleaned(training_fixture1_path))
         assert result == cleaned_csv_for_import_fixture


### PR DESCRIPTION
Sometimes in finance parentheses are used to indicate negative numbers. 