### PR TITLE
Allows numeric values that contain surrounding ()

### DIFF
--- a/modelmapper/mapper.py
+++ b/modelmapper/mapper.py
@@ -13,6 +13,7 @@ from collections import namedtuple
 from tabulate import tabulate
 
 from modelmapper.ui import get_user_choice, get_user_input, YES_NO_CHOICES
+from modelmapper.normalization import normalize_numberic_values
 from modelmapper.misc import (read_csv_gen, load_toml, write_toml,
                               named_tuple_to_compact_dict, escape_word, get_combined_dict,
                               write_full_python_file, update_file_chunk_content)
@@ -629,11 +630,6 @@ class Mapper:
         def _mark_nulls(item):
             return None if item in self.settings.null_values else item
 
-        def _remove_extra_chars_from_number(item):
-            for i in NUMERIC_REMOVE:
-                item = item.replace(i, '')
-            return item
-
         def _mark_booleans(item):
             if item in self.settings.boolean_true:
                 result = True
@@ -652,7 +648,7 @@ class Mapper:
                     raise ValueError(f'There is a value that is longer than {max_string_len} for {field_name}: {item}')
 
             if is_integer or is_decimal:
-                item = _remove_extra_chars_from_number(item)
+                item = normalize_numberic_values(item)
 
             if is_nullable:
                 item = _mark_nulls(item)

--- a/modelmapper/normalization.py
+++ b/modelmapper/normalization.py
@@ -1,0 +1,11 @@
+NUMERIC_REMOVE = (',', '$', '%', '-')
+
+
+def normalize_numberic_values(value, absolute=False):
+    if value.startswith('(') and value.endswith(')'):
+        value = value.strip('()')
+        value = f'-{value}'
+    for i in NUMERIC_REMOVE:
+        if not(i == '-' and not absolute):
+            value = value.replace(i, '')
+    return value

--- a/modelmapper/stats.py
+++ b/modelmapper/stats.py
@@ -3,6 +3,7 @@ import datetime
 from collections import Counter
 from typing import Any, NamedTuple
 
+from modelmapper.normalization import normalize_numberic_values
 from modelmapper.types import (
     HasBoolean,
     HasDateTime,
@@ -237,15 +238,12 @@ class PositiveIntMatcher(TypeMatcher, TypeAccumulator):
     def collect(self):
         return {'max_int': self.max_int }
 
-    def _normalize(self, item):
-        return item.replace('-', '').replace(',', '').replace('$', '').replace('%', '')
-
     def is_exclusive(self):
         return True
 
     def _get_positive_int(self, item):
         try:
-            return int(self._normalize(item))
+            return int(normalize_numberic_values(item, absolute=True))
         except ValueError:
             return False
 
@@ -300,14 +298,11 @@ class PositiveDecimalMatcher(TypeMatcher, TypeAccumulator):
         else:
             return 0, 0
 
-    def _normalize(self, item):
-        return item.replace('-', '').replace(',', '').replace('$', '').replace('%', '')
-
     def _get_positive_decimal(self, item):
         if '.' not in item:
             return False
         try:
-            return decimal.Decimal(self._normalize(item))
+            return decimal.Decimal(normalize_numberic_values(item, absolute=True))
         except decimal.InvalidOperation:
             return False
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -3,7 +3,6 @@ from collections import Counter
 from deepdiff import DeepDiff
 
 from modelmapper.stats import StatsCollector, FieldStats, InconsistentData
-from modelmapper.types import HasDateTime
 
 
 @pytest.fixture(scope='function')
@@ -89,6 +88,14 @@ def default_collector():
     (['$1,001.10', '$220.23', '0'],
      FieldStats(counter=Counter(HasInt=1, HasDecimal=2, HasBoolean=1, HasDollar=2),
                 max_int=0, len=3, max_decimal_scale=2, max_pre_decimal=4),
+     ),
+    (['$0.00', '($12,000.00)', '$7,765.00'],
+     FieldStats(counter=Counter({'HasDollar': 3, 'HasDecimal': 3}),
+                max_pre_decimal=5, max_decimal_scale=2, len=3)
+     ),
+    (['1', '1', '0', '0', '(20)'],
+     FieldStats(counter=Counter(HasBoolean=4, HasInt=5),
+                max_int=20, len=5),
      ),
 ])
 def test_expected_stats_with_defaults(default_collector, values, expected_stats):


### PR DESCRIPTION
Takes Sep's changes from #7 and applies them on top of the stats
refactor PR.

Financial data occasionally uses surrounding () marks to denote negative
values.