### PR TITLE
use passed in env var for slack

### DIFF
--- a/modelmapper/base.py
+++ b/modelmapper/base.py
@@ -39,7 +39,7 @@ class Base:
         for item in convert_to_set:
             self.settings[item] = set(self.settings.get(item, []))
         slack_http_endpoint = self.settings['slack_http_endpoint']
-        slack_http_endpoint = os.environ.get('slack_http_endpoint', slack_http_endpoint)
+        slack_http_endpoint = os.environ.get(slack_http_endpoint, slack_http_endpoint)  # attempts to get passed in value from ENV VAR, defaulting to passed in value
         self.settings['raw_headers_include'] = self.settings.get('raw_headers_include', {})
         self.settings['csv_delimiter'] = self.settings.get('csv_delimiter', ',')
         self.settings['slack_http_endpoint'] = slack_http_endpoint

--- a/modelmapper/base.py
+++ b/modelmapper/base.py
@@ -39,7 +39,8 @@ class Base:
         for item in convert_to_set:
             self.settings[item] = set(self.settings.get(item, []))
         slack_http_endpoint = self.settings['slack_http_endpoint']
-        slack_http_endpoint = os.environ.get(slack_http_endpoint, slack_http_endpoint)  # attempts to get passed in value from ENV VAR, defaulting to passed in value
+        # attempt to get passed in value from ENV VAR, defaulting to passed in value if not present
+        slack_http_endpoint = os.environ.get(slack_http_endpoint, slack_http_endpoint)
         self.settings['raw_headers_include'] = self.settings.get('raw_headers_include', {})
         self.settings['csv_delimiter'] = self.settings.get('csv_delimiter', ',')
         self.settings['slack_http_endpoint'] = slack_http_endpoint


### PR DESCRIPTION
Based on the comment in the generated `toml` files. The `slack_http_endpoint` should be able to point to an ENV var. Instead it's checking for the existance of a `"slack_http_endpoint"` ENV var, instead of what the value is set to. This should fix that.

Example from TOML file:
`slack_http_endpoint = "SLACK_HTTPS_ENDPOINT"  # slack htto endpoint for reporting errors when importing data. It can be an environment variable.`