### PR TITLE
fix string dates in excel

### DIFF
--- a/modelmapper/__init__.py
+++ b/modelmapper/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-__version__ = '0.7.1'
+__version__ = '0.7.2'
 import sys
 pyversion = float(sys.version[:3])
 if pyversion < 3.6:

--- a/modelmapper/cleaner.py
+++ b/modelmapper/cleaner.py
@@ -191,12 +191,19 @@ class Cleaner(Base):
             field_values[i] = item
 
         if is_datetime:
-            if is_excel:
-                def xls_date(x):
-                    return xldate_as_datetime(float(x), self.xls_date_mode)
-                field_values[:] = map(lambda x: None if x is None else xls_date(x), field_values)
-            else:
-                field_values[:] = map(lambda x: None if x is None else strptime(x, _format), field_values)
+            def convert_dates(x):
+                if x is None:
+                    return None
+                if isinstance(x, datetime.datetime):
+                    return x
+                try:
+                    return strptime(x, _format)
+                except ValueError:
+                    if is_excel:
+                        return xldate_as_datetime(float(x), self.xls_date_mode)
+
+            field_values[:] = map(convert_dates, field_values)
+
         return field_values
 
     def clean(self, content_type, path=None, content=None, sheet_names=None, ignore_missing_fields=True):

--- a/modelmapper/cleaner.py
+++ b/modelmapper/cleaner.py
@@ -194,8 +194,6 @@ class Cleaner(Base):
             def convert_dates(x):
                 if x is None:
                     return None
-                if isinstance(x, datetime.datetime):
-                    return x
                 try:
                     return strptime(x, _format)
                 except ValueError:

--- a/tests/test_cleaner.py
+++ b/tests/test_cleaner.py
@@ -4,6 +4,7 @@ import pytest
 
 from deepdiff import DeepDiff
 from modelmapper import Cleaner
+from modelmapper.mapper import SqlalchemyFieldType
 from tests.fixtures.training_fixture1_cleaned_for_import import cleaned_csv_for_import_fixture  # NOQA
 from tests.fixtures.training_fixture1_with_2_sheets_cleaned_for_import import cleaned_csv_with_2_sheets_combined_for_import_fixture  # NOQA
 
@@ -112,3 +113,13 @@ class TestCleaner:
         diff = DeepDiff(cleaned_csv_with_2_sheets_combined_for_import_fixture, results)
         for item in diff['values_changed'].keys():
             assert item.endswith("year']")
+
+    def test_clean_xlsx_string_date_values(self, cleaner):
+        field_info = {
+            'is_nullable': True,
+            'field_db_sqlalchemy_type': SqlalchemyFieldType.DateTime,
+            'datetime_formats': ['%Y/%m/%d']
+        }
+        field_values = ['2018/02/24']
+
+        assert field_values == cleaner._get_field_values_cleaned_for_importing('test_field', field_info, field_values, 'xlsx')


### PR DESCRIPTION
Fixes an issue where if an xlsx file has a date field that is saved as TEXT instead of as the excel date type, it would throw an error.