### PR TITLE
allow file reprocessing

### DIFF
--- a/modelmapper/etl.py
+++ b/modelmapper/etl.py
@@ -91,6 +91,13 @@ class ETL(Base):
             session.commit()
         except core_exc.IntegrityError:
             session.rollback()  # Signature already exists, so we're processing an existing file.
+
+            # let's grab the raw key id that already exists.
+            raw_key = session.query(
+                self.RAW_KEY_MODEL
+            ).filter(
+                self.RAW_KEY_MODEL.signature == signature
+            ).one()  # <-- raise exception if not found
         except Exception:
             session.rollback()
             raise


### PR DESCRIPTION
Right now if I want to reprocess a file, it will not be associated with the correct raw_key_id (it will return None). This catches the integrity error that fires when determining a duplicate file and instead grabs the existing row.