### PR TITLE
SC-114: Allow Flag-Based File Reprocessing

### DIFF
--- a/modelmapper/etl.py
+++ b/modelmapper/etl.py
@@ -100,7 +100,7 @@ class ETL(Base):
             session.commit()
         except core_exc.IntegrityError:
             session.rollback()
-            
+
             # We are attempting to process an existing file.
             if self._should_reprocess:
                 raw_key = session.query(

--- a/modelmapper/etl.py
+++ b/modelmapper/etl.py
@@ -170,7 +170,6 @@ class ETL(Base):
         else:
             raw_key_id = self._create_raw_key(session, key=key, signature=None)
 
-
         data = {"content": content, "raw_key_id": raw_key_id, "content_type": content_type,
                 "path": path, "sheet_names": sheet_names}
 

--- a/modelmapper/etl.py
+++ b/modelmapper/etl.py
@@ -27,8 +27,7 @@ class ETL(Base):
         self.JOB_NAME = self.__class__.__name__
         self.DUMP_FILEPATH = f'/tmp/{self.JOB_NAME}_dump'
 
-        self._should_reprocess = kwargs.get('should_reprocess', False)
-        kwargs.pop('should_reprocess', None)
+        self._should_reprocess = kwargs.pop('should_reprocess', None)
 
         super().__init__(*args, **kwargs)
         kwargs['setup_path'] = self.setup_path

--- a/modelmapper/etl.py
+++ b/modelmapper/etl.py
@@ -153,7 +153,7 @@ class ETL(Base):
         self.logger.info(f'Starting the {self.JOB_NAME} ...')
 
         if use_client:
-            content = self.get_client_data()
+            content = self.get_client_data(reprocess=self.__should_reprocess)
 
         # get_client_data may have returned a key for the raw_key value
         if isinstance(content, tuple):

--- a/modelmapper/etl.py
+++ b/modelmapper/etl.py
@@ -27,6 +27,7 @@ class ETL(Base):
         self.DUMP_FILEPATH = f'/tmp/{self.JOB_NAME}_dump'
 
         self._should_reprocess = kwargs.get('should_reprocess', False)
+        kwargs.pop('should_reprocess', None)
 
         super().__init__(*args, **kwargs)
         kwargs['setup_path'] = self.setup_path

--- a/modelmapper/etl.py
+++ b/modelmapper/etl.py
@@ -85,7 +85,7 @@ class ETL(Base):
             if isinstance(data['content'], types.GeneratorType):
                 # Since the type of data's content is a CSV we can unwrap the
                 # generator with list and just take it's first entry.
-                data['content'] = list(data['content'])[0]
+                data['content'] = next(data['content'])
 
             pickle.dump(data, the_file)
 

--- a/modelmapper/etl.py
+++ b/modelmapper/etl.py
@@ -99,7 +99,8 @@ class ETL(Base):
             session.add(raw_key)
             session.commit()
         except core_exc.IntegrityError:
-
+            session.rollback()
+            
             # We are attempting to process an existing file.
             if self._should_reprocess:
                 raw_key = session.query(
@@ -112,8 +113,6 @@ class ETL(Base):
                                  f'[Signature: {self.RAW_KEY_MODEL.signature}]')
 
                 return raw_key.id
-            else:
-                session.rollback()
 
         except Exception:
             session.rollback()

--- a/modelmapper/etl.py
+++ b/modelmapper/etl.py
@@ -1,7 +1,6 @@
 import gzip
 import datetime
 import logging
-import os
 import pickle
 
 from modelmapper.base import Base

--- a/modelmapper/etl.py
+++ b/modelmapper/etl.py
@@ -170,6 +170,7 @@ class ETL(Base):
         else:
             raw_key_id = self._create_raw_key(session, key=key, signature=None)
 
+
         data = {"content": content, "raw_key_id": raw_key_id, "content_type": content_type,
                 "path": path, "sheet_names": sheet_names}
 

--- a/modelmapper/etl.py
+++ b/modelmapper/etl.py
@@ -227,7 +227,8 @@ class ETL(Base):
             session.commit()
 
     def run(self, ping_slack=False, path=None, content=None, content_type=None,
-            sheet_names=None, use_client=True, backup_data=True, ignore_missing_fields=True):
+            sheet_names=None, use_client=True, backup_data=True, reprocess=False,
+            ignore_missing_fields=True):
         """Entrypoint for any ETL job
         Argumements:
             ping_slack (bool): should alert slack on error
@@ -235,10 +236,13 @@ class ETL(Base):
             content (?): source content
             content_type (str): input data type
             use_client (bool): use the given client for accessing data
+            reprocess (bool): Reprocess flag - forces a reprocessing of data
             ignore_missing_fields (bool): drop columns that are not defined in the provided model mapping
                                       instead of raising an error.
         """
         try:
+            self.__should_reprocess = reprocess
+
             with self.get_session() as session:
                 data = self._extract(session, path=path, content=content, content_type=content_type,
                                      sheet_names=sheet_names, use_client=use_client, backup_data=backup_data)

--- a/modelmapper/etl.py
+++ b/modelmapper/etl.py
@@ -2,6 +2,7 @@ import gzip
 import datetime
 import logging
 import pickle
+import types
 
 from modelmapper.base import Base
 from modelmapper.cleaner import Cleaner
@@ -82,6 +83,11 @@ class ETL(Base):
 
     def _dump_state_after_client_response(self, data):
         with open(f'{self.DUMP_FILEPATH}.pickle', "wb") as the_file:
+            if isinstance(data['content'], types.GeneratorType):
+                # Since the type of data's content is a CSV we can unwrap the
+                # generator with list and just take it's first entry.
+                data['content'] = list(data['content'])[0]
+
             pickle.dump(data, the_file)
 
     def _load_state_after_client_response(self):

--- a/modelmapper/etl.py
+++ b/modelmapper/etl.py
@@ -95,11 +95,8 @@ class ETL(Base):
             raw_key = self.RAW_KEY_MODEL(key=key, signature=signature)
             session.add(raw_key)
             session.commit()
-        except core_exc.IntegrityError:
+        except core_exc.IntegrityError: # We are processing an existing file.
             if self.__should_reprocess:
-                # We are processing an existing file so let's return the raw_key
-                # so the code will automagically re-process.
-
                 raw_key = session.query(
                     self.RAW_KEY_MODEL
                 ).filter(

--- a/modelmapper/etl.py
+++ b/modelmapper/etl.py
@@ -228,7 +228,7 @@ class ETL(Base):
             session.commit()
 
     def run(self, ping_slack=False, path=None, content=None, content_type=None,
-            sheet_names=None, use_client=True, backup_data=True, reprocess=False,
+            sheet_names=None, use_client=True, backup_data=True,
             ignore_missing_fields=True):
         """Entrypoint for any ETL job
         Argumements:
@@ -237,13 +237,10 @@ class ETL(Base):
             content (?): source content
             content_type (str): input data type
             use_client (bool): use the given client for accessing data
-            reprocess (bool): Reprocess flag - forces a reprocessing of data
             ignore_missing_fields (bool): drop columns that are not defined in the provided model mapping
                                       instead of raising an error.
         """
         try:
-            self._should_reprocess = reprocess
-
             with self.get_session() as session:
                 data = self._extract(session, path=path, content=content, content_type=content_type,
                                      sheet_names=sheet_names, use_client=use_client, backup_data=backup_data)

--- a/requirements-loader.txt
+++ b/requirements-loader.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 mmh3==2.5.1
 requests==2.21.0
-SQLAlchemy==1.2.6
+SQLAlchemy==1.3.7
 boto3==1.7.11

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
 import sys
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), 'tests'))) # noqa
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                             'tests')))

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -77,7 +77,6 @@ class TestETL:
         test_etl.RAW_KEY_MODEL = Mock()
         actual_id = test_etl._create_raw_key(mock_session, "123", "123")
 
-        assert actual_id == mock_raw_key.id
         assert actual_id == '123'
 
     @pytest.mark.parametrize('fn_name, arg_count', [

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -67,7 +67,7 @@ class TestETL:
         # Running it a second time should not throw any exceptions
         data = job_with_reprocess._extract(None, backup_data=False, content_type='csv')
 
-        assert not isinstance(data['content'], GeneratorType)
+        assert isinstance(data['content'], GeneratorType)
 
     @pytest.mark.parametrize('fn_name, arg_count', [
         ('get_client_data', 0),

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -19,6 +19,9 @@ with open(training_fixture1_path, 'r', encoding='utf-8-sig') as the_file:
 def job():
     return ETL(setup_path=example_setup_path)
 
+@pytest.fixture(scope='module')
+def job_with_reprocess():
+    return ETL(setup_path=example_setup_path, should_reprocess=True)
 
 @pytest.fixture(scope='module')
 def basic():
@@ -41,6 +44,30 @@ class TestETL:
         mock_create_raw_key.return_value = uuid4()
         data = job._extract(None, backup_data=False, content_type='csv')
         assert isinstance(data['content'], GeneratorType)
+
+    @mock.patch('modelmapper.ETL.get_client_data')
+    @mock.patch('modelmapper.ETL._create_raw_key')
+    def test_extract_no_generator_with_reprocess(self, mock_client_data, mock_create_raw_key, job_with_reprocess):
+        mock_client_data.return_value = training_fixture1_content_str
+        mock_create_raw_key.return_value = uuid4()
+        job_with_reprocess._extract(None, backup_data=False, content_type='csv')
+
+        # Running it a second time should not throw any exceptions
+        data = job_with_reprocess._extract(None, backup_data=False, content_type='csv')
+
+        assert not isinstance(data['content'], GeneratorType)
+
+    @mock.patch('modelmapper.ETL.get_client_data')
+    @mock.patch('modelmapper.ETL._create_raw_key')
+    def test_extract_generator_with_reprocess(self, mock_client_data, mock_create_raw_key, job_with_reprocess):
+        mock_client_data.return_value = yield training_fixture1_content_str
+        mock_create_raw_key.return_value = uuid4()
+        job_with_reprocess._extract(None, backup_data=False, content_type='csv')
+
+        # Running it a second time should not throw any exceptions
+        data = job_with_reprocess._extract(None, backup_data=False, content_type='csv')
+
+        assert not isinstance(data['content'], GeneratorType)
 
     @pytest.mark.parametrize('fn_name, arg_count', [
         ('get_client_data', 0),

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -1,9 +1,11 @@
 import os
 from types import GeneratorType
 from unittest import mock
+from unittest.mock import Mock
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import exc as core_exc
 
 from modelmapper import ETL
 from tests.fixtures.etl import BasicETL
@@ -20,51 +22,52 @@ def job():
     return ETL(setup_path=example_setup_path)
 
 @pytest.fixture(scope='module')
-def job_with_reprocess():
-    return ETL(setup_path=example_setup_path, should_reprocess=True)
-
-@pytest.fixture(scope='module')
 def basic():
     return BasicETL(setup_path=example_setup_path)
 
 def content_generator():
     yield training_fixture1_content_str
 
+
 class TestETL:
-    @mock.patch('modelmapper.ETL.get_client_data')
     @mock.patch('modelmapper.ETL._create_raw_key')
+    @mock.patch('modelmapper.ETL.get_client_data')
     def test_extract_generator(self, mock_client_data, mock_create_raw_key, job):
         mock_client_data.return_value = content_generator()
         mock_create_raw_key.return_value = uuid4()
         data = job._extract(None, backup_data=False, content_type='csv')
 
-        assert list(data['content'][0]) == training_fixture1_content_str
+        assert ''.join(list(data['content'])) == training_fixture1_content_str
 
-    @mock.patch('modelmapper.ETL.get_client_data')
     @mock.patch('modelmapper.ETL._create_raw_key')
+    @mock.patch('modelmapper.ETL.get_client_data')
     def test_extract_no_generator(self, mock_client_data, mock_create_raw_key, job):
         mock_client_data.return_value = training_fixture1_content_str
+
         mock_create_raw_key.return_value = uuid4()
-        job_with_reprocess._extract(None, backup_data=False, content_type='csv')
+
         data = job._extract(None, backup_data=False, content_type='csv')
 
-        # Running it a second time should not throw any exceptions
-        data = job_with_reprocess._extract(None, backup_data=False, content_type='csv')
-
-        assert not isinstance(data['content'], GeneratorType)
         assert data['content'] == training_fixture1_content_str
 
-    @mock.patch('modelmapper.ETL.get_client_data')
-    @mock.patch('modelmapper.ETL._create_raw_key')
-    def test_extract_generator_with_reprocess(self, mock_client_data, mock_create_raw_key, job_with_reprocess):
-        mock_client_data.return_value = yield training_fixture1_content_str
-        mock_create_raw_key.return_value = uuid4()
-        job_with_reprocess._extract(None, backup_data=False, content_type='csv')
+    def test_reprocess_in_create_raw_key(self):
+        mock_raw_key = Mock()
+        mock_raw_key.id = "123"
 
-        # Running it a second time should not throw any exceptions
-        data = job_with_reprocess._extract(None, backup_data=False, content_type='csv')
+        # This mock simulates the case where the create raw key function
+        # is called and received a duplicate key. It raises an
+        # IntegrityError which triggers our reprocessing code if the
+        # reprocessing feature is enabled.
+        mock_session = Mock()
+        mock_session.commit = Mock()
+        mock_session.commit.side_effect = core_exc.IntegrityError
+        mock_session.query = Mock()
+        mock_session.query.return_value = mock_raw_key
 
-        assert isinstance(data['content'], GeneratorType)
+        test_etl = ETL(setup_path=example_setup_path, should_reprocess=True)
+        actual_id = test_etl._create_raw_key(mock_session, "123", "123")
+
+        assert actual_id == mock_raw_key.id
 
     @pytest.mark.parametrize('fn_name, arg_count', [
         ('get_client_data', 0),

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -33,14 +33,6 @@ def content_generator():
 class TestETL:
     @mock.patch('modelmapper.ETL.get_client_data')
     @mock.patch('modelmapper.ETL._create_raw_key')
-    def test_extract_no_generator(self, mock_client_data, mock_create_raw_key, job):
-        mock_client_data.return_value = training_fixture1_content_str
-        mock_create_raw_key.return_value = uuid4()
-        data = job._extract(None, backup_data=False, content_type='csv')
-        assert not isinstance(data['content'], GeneratorType)
-
-    @mock.patch('modelmapper.ETL.get_client_data')
-    @mock.patch('modelmapper.ETL._create_raw_key')
     def test_extract_generator(self, mock_client_data, mock_create_raw_key, job):
         mock_client_data.return_value = content_generator()
         mock_create_raw_key.return_value = uuid4()

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -42,7 +42,6 @@ class TestETL:
     @mock.patch('modelmapper.ETL.get_client_data')
     @mock.patch('modelmapper.ETL._create_raw_key')
     def test_extract_generator(self, mock_client_data, mock_create_raw_key, job):
-        mock_client_data.return_value = yield training_fixture1_content_str
         mock_client_data.return_value = content_generator()
         mock_create_raw_key.return_value = uuid4()
         data = job._extract(None, backup_data=False, content_type='csv')

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -51,7 +51,6 @@ class TestETL:
 
     @mock.patch('modelmapper.ETL.get_client_data')
     @mock.patch('modelmapper.ETL._create_raw_key')
-    def test_extract_no_generator_with_reprocess(self, mock_client_data, mock_create_raw_key, job_with_reprocess):
     def test_extract_no_generator(self, mock_client_data, mock_create_raw_key, job):
         mock_client_data.return_value = training_fixture1_content_str
         mock_create_raw_key.return_value = uuid4()

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -71,8 +71,6 @@ class TestETL:
 
         mock_session.query = Mock(return_value=filter_mock)
 
-        print(mock_session.query().filter().one().id)
-
         test_etl = ETL(setup_path=example_setup_path, should_reprocess=True)
         test_etl.RAW_KEY_MODEL = Mock()
         actual_id = test_etl._create_raw_key(mock_session, "123", "123")


### PR DESCRIPTION
Added this to create a flag-based reprocessing system that we can call from `command.py` over in asset-mgmt.